### PR TITLE
add hreflang tag feature

### DIFF
--- a/Block/StructuredData/Hreflang.php
+++ b/Block/StructuredData/Hreflang.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Fox\Seo\Block\StructuredData;
+
+use Magento\Framework\Pricing\PriceCurrencyInterface;
+
+class Hreflang extends \Magento\Framework\View\Element\Template
+{
+    /** @var \Magento\Framework\Registry */
+    protected $registry;
+
+    /**
+     * @param \Magento\Framework\View\Element\Template\Context $context
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+     * @param array $data
+     */
+    public function __construct(
+        \Magento\Framework\View\Element\Template\Context $context,
+        \Magento\Framework\Registry $registry,
+        array $data = []
+    )
+    {
+        $this->registry = $registry;
+        parent::__construct($context, $data);
+    }
+
+    /**
+     * Get this website's language codes & URLs.
+     *
+     * @return array
+     *   Keyed by language code, value is store's base URL.
+     */
+    public function getLangs() {
+        $storelangs = [];
+        $currentWebsiteId = $this->getCurrentWebsiteId();
+        $product = $this->registry->registry('current_product');
+
+        foreach ($this->_storeManager->getStores() as $code => $store) {
+            if ($store->getWebsiteId() === $currentWebsiteId) {
+                $storeUrl = $product->setStoreId($store->getId())->getUrlInStore();
+                $storeLangcode = $this->_scopeConfig->getValue('general/locale/code', \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $code);
+                $storelangs[$storeLangcode] = $storeUrl;
+            }
+        }
+
+        return $storelangs;
+    }
+
+    /**
+     * @return int
+     */
+    protected function getCurrentWebsiteId()
+    {
+        return $this->_storeManager->getStore()->getWebsiteId();
+    }
+}

--- a/Block/StructuredData/Hreflang.php
+++ b/Block/StructuredData/Hreflang.php
@@ -39,6 +39,8 @@ class Hreflang extends \Magento\Framework\View\Element\Template
             if ($store->getWebsiteId() === $currentWebsiteId) {
                 $storeUrl = $product->setStoreId($store->getId())->getUrlInStore();
                 $storeLangcode = $this->_scopeConfig->getValue('general/locale/code', \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $code);
+                // Google wants langcodes with dashes rather than underscores;
+                $storeLangcode = str_replace('_', '-', $storeLangcode);
                 $storelangs[$storeLangcode] = $storeUrl;
             }
         }

--- a/Observer/DefaultProductMeta.php
+++ b/Observer/DefaultProductMeta.php
@@ -35,6 +35,14 @@ class DefaultProductMeta implements ObserverInterface
     {
         $category = $observer->getEvent()->getCategory();
 
+        // Maybe the category is in the product?
+        if ($category === null) {
+            $category = $observer->getEvent()->getProduct()->getCategory();
+        }
+
+        // Or maybe there's just no category.
+        if ($category === null) return;
+
         $this->_foxSeoHelper->checkMetaData($category, 'category');
 
         if ($robots = $category->getData('foxseo_metarobots'))

--- a/composer.json
+++ b/composer.json
@@ -3,13 +3,7 @@
     "description": "An SEO extension for Magento 2",
     "homepage": "https://github.com/adampmoss/foxseo2",
     "require": {
-        "php": "~5.5.0|~5.6.0|~7.0.0",
-        "magento/module-store": "100.0.*",
-        "magento/magento-composer-installer": "*",
-        "magento/module-catalog": "100.0.*",
-        "magento/module-eav": "100.0.*",
-        "magento/framework": "100.0.*",
-        "magento/module-config": "100.0.*"
+        "magento/magento-composer-installer": "*"
     },
     "type": "magento2-module",
     "version": "2.0.0",

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -424,6 +424,24 @@
                     <comment><![CDATA[Enable this field only if you submit feeds for Google Shopping.]]></comment>
                 </field>
             </group>
+
+            <!--
+                link alternative hreflang
+            -->
+
+            <group id="hreflang" translate="label" type="text" sortOrder="131" showInDefault="1" showInWebsite="1"
+                   showInStore="1">
+                <label>Language and Regional URLs</label>
+                <comment>
+                    <![CDATA[
+                            <p>Provide metadata to inform search enginges about alternative versions of the same page for different languages and regions. This metadata is rendered in the HTML head as <code>rel="alternate" hreflang="x"</code></p>
+                        ]]>
+                </comment>
+                <field id="enabled" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Enable Language and Regional URLs?</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+            </group>
         </section>
     </system>
 </config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -55,6 +55,9 @@
                 <enabled>0</enabled>
                 <badge_position>gts_bottom_right</badge_position>
             </google_trusted_store>
+            <hreflang>
+                <enabled>0</enabled>
+            </hreflang>
         </foxseo>
     </default>
 </config>

--- a/view/adminhtml/templates/checklist.phtml
+++ b/view/adminhtml/templates/checklist.phtml
@@ -7,6 +7,7 @@
     <?php echo $block->check('foxseo/settings/forcecanonical', '1', __('Canonical product redirects')) ?>
     <?php echo $block->check('foxseo/settings/enablecmscanonical', '1', __('Canonical meta tag for CMS pages')) ?>
     <?php echo $block->check('foxseo/twittercards/enabled', '1', __('Twitter cards on product pages')) ?>
+    <?php echo $block->check('foxseo/hreflang/enabled', '1', __('Language and Regional URLs')) ?>
     <?php echo $block->check('foxseo/organization_sd/enabled', '1', __('Organization structured data')) ?>
     <?php echo $block->check('foxseo/social_sd/enabled', '1', __('Social structured data')) ?>
     <?php echo $block->check('foxseo/logo_sd/enabled', '1', __('Logo structured data')) ?>

--- a/view/frontend/layout/catalog_product_view.xml
+++ b/view/frontend/layout/catalog_product_view.xml
@@ -2,6 +2,7 @@
     <body>
         <referenceBlock name="head.additional">
             <block class="Fox\Seo\Block\StructuredData\TwitterCards" name="foxseo.twittercards" template="Fox_Seo::structureddata/twittercards.phtml" ifconfig="foxseo/twittercards/enabled" />
+            <block class="Fox\Seo\Block\StructuredData\Hreflang" name="foxseo.hreflang" template="Fox_Seo::structureddata/hreflang.phtml" ifconfig="foxseo/hreflang/enabled" />
         </referenceBlock>
         <referenceBlock name="footer">
             <block class="Fox\Seo\Block\Template" name="foxseo.content.grouping" template="Fox_Seo::google/content-grouping.phtml" ifconfig="foxseo/google_content_grouping/product">

--- a/view/frontend/templates/structureddata/hreflang.phtml
+++ b/view/frontend/templates/structureddata/hreflang.phtml
@@ -1,0 +1,6 @@
+<?php $langs = $block->getLangs(); ?>
+<?php if ($langs && is_array($langs)): ?>
+    <?php foreach ($langs as $code => $url) : ?>
+        <link rel="alternate" href="<?php echo $url; ?>" hreflang="<?php echo $code; ?>"/>
+    <?php endforeach; ?>
+<?php endif; ?>


### PR DESCRIPTION
this PR adds a feature to support the [hreflang link tag](https://support.google.com/webmasters/answer/189077?hl=en) so search engines can see other versions of the same product URL -- this is useful for stores with a store view for each language/region.

also it fixes (what i think is) a bug in composer.json that prevents it from working with a project that used the magento starter package.

finally there's a fix for a bug i ran into where product category info is not available.

i can split these into multiple PRs if that makes more sense!